### PR TITLE
some setup actions need HOME environment value

### DIFF
--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -95,6 +95,8 @@ if [ $(id -u) -eq 0 ]; then  # if root
 sudo_prefix="sudo -E -u ${RUNNER_USER} "
 fi
 
+export HOME="/home/${RUNNER_USER}"
+
 echo "Configuring runner @ ${runner_scope}"
 
 #---------------------------------------


### PR DESCRIPTION
e.g. [actions/setup-go](https://github.com/actions/setup-go) 

setup-go need GOPATH, GOPATH default value is `$HOME/go`.