### PR TITLE
compress setup script by gzip and base64

### DIFF
--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -52,10 +52,7 @@ func (s *Starter) getSetupScript(target datastore.Target) (string, error) {
 	}
 	encoded := base64.StdEncoding.EncodeToString(compressedScript.Bytes())
 
-	script := fmt.Sprintf(templateCompressedScript,
-		encoded)
-
-	return script, nil
+	return fmt.Sprintf(templateCompressedScript, encoded), nil
 }
 
 func (s *Starter) getSetupRawScript(target datastore.Target) (string, error) {


### PR DESCRIPTION
`user-data` in cloud-init can not receive the long scripts in some environments.

So compress by gzip and base64, and decompress in a worker.