### PR TITLE
Org token and Repo token has a same installation ID

### DIFF
--- a/pkg/gh/token_registration.go
+++ b/pkg/gh/token_registration.go
@@ -56,7 +56,7 @@ func generateRunnerRegisterToken(ctx context.Context, gheDomain string, installa
 }
 
 func setRunnerRegisterTokenCache(installationID int64, scope, token string, expiresAt time.Time) {
-	expiresDuration := time.Until(expiresAt.Add(-time.Minute))
+	expiresDuration := time.Until(expiresAt.Add(-6 * time.Minute))
 
 	cacheRegistrationToken.Set(getCacheKeyRegistrationToken(installationID, scope), token, expiresDuration)
 }


### PR DESCRIPTION
This change fixes this error.

```
./config.sh --unattended --url https://github.com/xxx/xxx --token *** --name myshoes-xxx --labels myshoes --ephemeral

--------------------------------------------------------------------------------
|        ____ _ _   _   _       _          _        _   _                      |
|       / ___(_) |_| | | |_   _| |__      / \   ___| |_(_) ___  _ __  ___      |
|      | |  _| | __| |_| | | | | '_ \    / _ \ / __| __| |/ _ \| '_ \/ __|     |
|      | |_| | | |_|  _  | |_| | |_) |  / ___ \ (__| |_| | (_) | | | \__ \     |
|       \____|_|\__|_| |_|\__,_|_.__/  /_/   \_\___|\__|_|\___/|_| |_|___/     |
|                                                                              |
|                       Self-hosted runner registration                        |
|                                                                              |
--------------------------------------------------------------------------------

# Authentication

Http response code: NotFound from 'POST https://api.github.com/actions/runner-registration'
{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}
Response status code does not indicate success: 404 (Not Found).
```