### PR TITLE
fix GHEDomain in TargetCreateParam

### DIFF
--- a/pkg/web/target.go
+++ b/pkg/web/target.go
@@ -23,6 +23,7 @@ import (
 type TargetCreateParam struct {
 	datastore.Target
 
+	GHEDomain   *string `json:"ghe_domain"`   // ignore
 	RunnerUser  *string `json:"runner_user"`  // nullable
 	ProviderURL *string `json:"provider_url"` // nullable
 }


### PR DESCRIPTION
Prevent an error even if the user specifies ghe_domain when registering a target

- user command example
```
$ curl -XPOST https://${myshoes_shot} -d '{"scope": "xxxx", "ghe_domain": "", "resource_type": "large",  "runner_user": "runner", "runner_version": "v2.302.1"}'
{"error":"json decode error"}
```

- myshoes error log
```
myshoes 2023/03/08 05:24:22 failed to decode request body: json: cannot unmarshal string into Go struct field TargetCreateParam.ghe_domain of type sql.NullString
```