### PR TITLE
Fix plugin path variable in log output

### DIFF
--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -71,7 +71,7 @@ func Load() {
 		log.Panicf("failed to check plugin binary: %+v", err)
 	}
 	c.ShoesPluginPath = absPath
-	log.Printf("use plugin path is %s\n", Config.ShoesPluginPath)
+	log.Printf("use plugin path is %s\n", c.ShoesPluginPath)
 
 	Config = c
 }


### PR DESCRIPTION
The plugin path displayed empty because the Config variable was referenced before it was assigned to the Config variable.

Therefore, the issue has been corrected.