### PR TITLE
Do not execute backquoted as shell command in RunnerService.js

### DIFF
--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -344,7 +344,7 @@ trap - TERM INT
 wait \$PID
 EOF
 
-cat << EOF > ./bin/RunnerService.js
+cat << 'EOF' > ./bin/RunnerService.js
 {{.RunnerServiceJS}}
 EOF
 


### PR DESCRIPTION
The following line was interpreted by bash causing the `Runner listener exited with error code ` to be executed as a command.

https://github.com/whywaita/myshoes/blob/309d5260eb41cf6a234a0c2b1a110a94bb937406/pkg/starter/scripts/RunnerService.js#L44