### PR TITLE
Support job management hooks

### DIFF
--- a/docs/01_02_for_admin_tips.md
+++ b/docs/01_02_for_admin_tips.md
@@ -1,0 +1,9 @@
+# Tips for myshoes admin
+
+## Job management hooks for self-hosted runners
+
+You can use job management hooks for self-hosted runners.
+Please set script file to your runner image.
+
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED`: `/myshoes-actions-runner-hook-job-started.sh`
+- `ACTIONS_RUNNER_HOOK_JOB_COMPLETED`: `/myshoes-actions-runner-hook-job-completed.sh`

--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -353,6 +353,18 @@ cat << 'EOF' > ./bin/RunnerService.js
 EOF
 
 #---------------------------------------
+# Configure run commands
+#---------------------------------------
+
+# Configure job management hooks if script files exist
+if [ -e "/myshoes-actions-runner-hook-job-started.sh" ]; then
+	export ACTIONS_RUNNER_HOOK_JOB_STARTED="/myshoes-actions-runner-hook-job-started.sh"
+fi
+if [ -e "/myshoes-actions-runner-hook-job-completed.sh" ]; then
+	export ACTIONS_RUNNER_HOOK_JOB_COMPLETED="/myshoes-actions-runner-hook-job-completed.sh"
+fi
+
+#---------------------------------------
 # run!
 #---------------------------------------
 {{ if eq .RunnerArg "--once" -}}


### PR DESCRIPTION
https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/

- `ACTIONS_RUNNER_HOOK_JOB_STARTED`: `/myshoes-actions-runner-hook-job-started.sh`
- `ACTIONS_RUNNER_HOOK_JOB_COMPLETED`: `/myshoes-actions-runner-hook-job-completed.sh`