### PR TITLE
Add description for GITHUB_APP_SECRET environment variable in 01_01_for_admin_setup.md

### DIFF
--- a/docs/01_01_for_admin_setup.md
+++ b/docs/01_01_for_admin_setup.md
@@ -78,7 +78,7 @@ A config variables can set from environment values.
 - GitHub Apps information
   - required
   - `GITHUB_APP_ID`
-  - `GITHUB_APP_SECRET` (if you set)
+  - `GITHUB_APP_SECRET` (if you set `Webhook secret` for your GitHub App)
   - `GITHUB_PRIVATE_KEY_BASE64`
     - base64 encoded private key from GitHub Apps
     - `$ cat privatekey.pem | base64 -w 0`


### PR DESCRIPTION
The environment variable `GITHUB_APP_SECRET` must be equal to the GitHub App's webhook secret, but that wasn't obvious to me, so I added a description to make it clear.