### PR TITLE
Add error handling for invalid labels to AddInstance()

### DIFF
--- a/pkg/shoes/shoes.go
+++ b/pkg/shoes/shoes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/whywaita/myshoes/pkg/datastore"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -89,8 +90,8 @@ func (c *GRPCClient) AddInstance(ctx context.Context, runnerName, setupScript st
 	}
 	resp, err := c.client.AddInstance(ctx, req)
 	if err != nil {
-		// if invalid labels will delete job
-		if stat, _ := status.FromError(err); stat.Code() == 3 {
+		// will delete a job if labels of a job are invalid
+		if stat, _ := status.FromError(err); stat.Code() == codes.InvalidArgument {
 			return "", "", "", datastore.ResourceTypeUnknown, err
 		}
 		return "", "", "", datastore.ResourceTypeUnknown, fmt.Errorf("failed to AddInstance: %w", err)

--- a/pkg/shoes/shoes.go
+++ b/pkg/shoes/shoes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/whywaita/myshoes/pkg/datastore"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
 )
 
 // GetClient retrieve ShoesClient use shoes-plugin
@@ -88,6 +89,10 @@ func (c *GRPCClient) AddInstance(ctx context.Context, runnerName, setupScript st
 	}
 	resp, err := c.client.AddInstance(ctx, req)
 	if err != nil {
+		// if invalid labels will delete job
+		if stat, _ := status.FromError(err); stat.Code() == 3 {
+			return "", "", "", datastore.ResourceTypeUnknown, err
+		}
 		return "", "", "", datastore.ResourceTypeUnknown, fmt.Errorf("failed to AddInstance: %w", err)
 	}
 

--- a/pkg/starter/starter.go
+++ b/pkg/starter/starter.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/google/go-github/v47/github"
@@ -199,7 +200,7 @@ func (s *Starter) ProcessJob(ctx context.Context, job datastore.Job) error {
 	if err != nil {
 		logger.Logf(false, "failed to bung (target ID: %s, job ID: %s): %+v\n", job.TargetID, job.UUID, err)
 
-		if stat, _ := status.FromError(err); stat.Code() == 3 {
+		if stat, _ := status.FromError(err); stat.Code() == codes.InvalidArgument {
 			if err := s.ds.DeleteJob(ctx, job.UUID); err != nil {
 				logger.Logf(false, "failed to delete job: %+v\n", err)
 
@@ -301,7 +302,7 @@ func (s *Starter) bung(ctx context.Context, job datastore.Job, target datastore.
 
 	cloudID, ipAddress, shoesType, resourceType, err := client.AddInstance(ctx, runnerName, script, target.ResourceType, labels)
 	if err != nil {
-		if stat, _ := status.FromError(err); stat.Code() == 3 {
+		if stat, _ := status.FromError(err); stat.Code() == codes.InvalidArgument {
 			return "", "", "", datastore.ResourceTypeUnknown, err
 		}
 		return "", "", "", datastore.ResourceTypeUnknown, fmt.Errorf("failed to add instance: %w", err)

--- a/pkg/starter/starter.go
+++ b/pkg/starter/starter.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/status"
 
 	"github.com/google/go-github/v47/github"
 	uuid "github.com/satori/go.uuid"
@@ -198,6 +199,18 @@ func (s *Starter) ProcessJob(ctx context.Context, job datastore.Job) error {
 	if err != nil {
 		logger.Logf(false, "failed to bung (target ID: %s, job ID: %s): %+v\n", job.TargetID, job.UUID, err)
 
+		if stat, _ := status.FromError(err); stat.Code() == 3 {
+			if err := s.ds.DeleteJob(ctx, job.UUID); err != nil {
+				logger.Logf(false, "failed to delete job: %+v\n", err)
+
+				if err := datastore.UpdateTargetStatus(ctx, s.ds, job.TargetID, datastore.TargetStatusErr, fmt.Sprintf("job id: %s", job.UUID)); err != nil {
+					return fmt.Errorf("failed to update target status (target ID: %s, job ID: %s): %w", job.TargetID, job.UUID, err)
+				}
+
+				return fmt.Errorf("failed to delete job: %w", err)
+			}
+		}
+
 		if err := datastore.UpdateTargetStatus(ctx, s.ds, job.TargetID, datastore.TargetStatusErr, fmt.Sprintf("failed to create an instance (job ID: %s)", job.UUID)); err != nil {
 			return fmt.Errorf("failed to update target status (target ID: %s, job ID: %s): %w", job.TargetID, job.UUID, err)
 		}
@@ -288,6 +301,9 @@ func (s *Starter) bung(ctx context.Context, job datastore.Job, target datastore.
 
 	cloudID, ipAddress, shoesType, resourceType, err := client.AddInstance(ctx, runnerName, script, target.ResourceType, labels)
 	if err != nil {
+		if stat, _ := status.FromError(err); stat.Code() == 3 {
+			return "", "", "", datastore.ResourceTypeUnknown, err
+		}
 		return "", "", "", datastore.ResourceTypeUnknown, fmt.Errorf("failed to add instance: %w", err)
 	}
 


### PR DESCRIPTION
fixes: #183 

Change DeleteJobs to run when invalid labels are enqueued and InvalidArgument is returned by AddInstance().

For example, when AddInstance() is executed, jobs with InvalidArgument are never deleted.
Therefore, it will remain in the queue and may hit the rate limit of GitHubAPI.