### PR TITLE
Default is actually check_run

### DIFF
--- a/docs/01_01_for_admin_setup.md
+++ b/docs/01_01_for_admin_setup.md
@@ -116,9 +116,9 @@ For tuning values
   - default: true
   - set strict mode
 - `MODE_WEBHOOK_TYPE`
-  - default: `workflow_job` (use receive `workflow_job` event)
+  - default: `check_run` (use receive `workflow_job` event)
   - Set type of webhook from GitHub
-  - option: `check_run`
+  - option: `workflow_job`
 - `MAX_CONNECTIONS_TO_BACKEND`
   - default: 50
   - The number of max connections to shoes-provider


### PR DESCRIPTION
I found this today on my own instance of myshoes. 

`2024/05/02 19:40:00 receive WorkflowJobEvent, but set check_run. So ignore`

I checked the code ...
https://github.com/whywaita/myshoes/blob/603c51b07c194f6d0e98218b65a5568ce8e3fc2c/pkg/config/init.go#L63

and indeed the default is not `workflow_job`