### PR TITLE
Populate labels in the generated script.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,3 +103,5 @@ func marshalModeWebhookType(in string) ModeWebhookType {
 func (c Conf) IsGHES() bool {
 	return !strings.EqualFold(c.GitHubURL, "https://github.com")
 }
+
+const RequiredMyShoesLabel = "myshoes"

--- a/pkg/web/webhook.go
+++ b/pkg/web/webhook.go
@@ -204,7 +204,7 @@ func receiveWorkflowJobWebhook(ctx context.Context, event *github.WorkflowJobEve
 
 func isRequestedMyshoesLabel(labels []string) bool {
 	for _, label := range labels {
-		if strings.EqualFold(label, "myshoes") || strings.EqualFold(label, "self-hosted") {
+		if strings.EqualFold(label, config.RequiredMyShoesLabel) || strings.EqualFold(label, "self-hosted") {
 			return true
 		}
 	}


### PR DESCRIPTION
As mentioned https://github.com/whywaita/shoes-aws/pull/2#issuecomment-2093526663 in sister PR https://github.com/whywaita/shoes-aws/pull/2

now that I'm doing full integration testing, it is clear that the script needs the labels from GH otherwise jobs won't schedule.

