### PR TITLE
Generate a mysqlURL from host, port, user, password, database

### DIFF
--- a/docs/01_01_for_admin_setup.md
+++ b/docs/01_01_for_admin_setup.md
@@ -85,6 +85,11 @@ A config variables can set from environment values.
 - `MYSQL_URL`
   - required
   - DataSource Name, ex) `username:password@tcp(localhost:3306)/myshoes`
+  - if `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DATABASE` all are set, this env value are ignored.
+- `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_DATABASE`
+  - optional
+  - If all environment variables are set, mysql_url is constructed and loaded in the following way, then `MYSQL_URL` env will be ignored.
+  - example) `${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DATABASE}`
 - `PLUGIN`
   - required
   - set path of myshoes-provider binary.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ type Conf struct {
 	GitHubURL     string
 	RunnerVersion string
 
-	DockerHubCredential DockerHubCredential
+	DockerHubCredential     DockerHubCredential
 	ProvideDockerHubMetrics bool
 }
 
@@ -51,6 +51,11 @@ const (
 	EnvGitHubAppID               = "GITHUB_APP_ID"
 	EnvGitHubAppSecret           = "GITHUB_APP_SECRET"
 	EnvGitHubAppPrivateKeyBase64 = "GITHUB_PRIVATE_KEY_BASE64"
+	EnvMySQLHost                 = "MYSQL_HOST"
+	EnvMySQLPort                 = "MYSQL_PORT"
+	EnvMySQLUser                 = "MYSQL_USER"
+	EnvMySQLPassword             = "MYSQL_PASSWORD"
+	EnvMySQLDatabase             = "MYSQL_DATABASE"
 	EnvMySQLURL                  = "MYSQL_URL"
 	EnvPort                      = "PORT"
 	EnvShoesPluginPath           = "PLUGIN"

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -199,6 +199,7 @@ func LoadMySQLURL() string {
 	mysqlDatabase, ok_Database := os.LookupEnv(EnvMySQLDatabase)
 	if ok_Host && ok_Port && ok_User && ok_Password && ok_Database {
 		mysqlURL := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", mysqlUser, mysqlPassword, mysqlHost, mysqlPort, mysqlDatabase)
+		log.Println("load MySQL URL from environment variables MYSQL_USER, MYSQL_PASSWORD, MYSQL_HOST, MYSQL_PORT, MYSQL_DATABASE, not MYSQL_URL")
 		return mysqlURL
 	}
 	mysqlURL := os.Getenv(EnvMySQLURL)

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -192,6 +192,15 @@ func LoadGitHubApps() *GitHubApp {
 
 // LoadMySQLURL load MySQL URL from environment
 func LoadMySQLURL() string {
+	mysqlHost, ok_Host := os.LookupEnv(EnvMySQLHost)
+	mysqlPort, ok_Port := os.LookupEnv(EnvMySQLPort)
+	mysqlUser, ok_User := os.LookupEnv(EnvMySQLUser)
+	mysqlPassword, ok_Password := os.LookupEnv(EnvMySQLPassword)
+	mysqlDatabase, ok_Database := os.LookupEnv(EnvMySQLDatabase)
+	if ok_Host && ok_Port && ok_User && ok_Password && ok_Database {
+		mysqlURL := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", mysqlUser, mysqlPassword, mysqlHost, mysqlPort, mysqlDatabase)
+		return mysqlURL
+	}
 	mysqlURL := os.Getenv(EnvMySQLURL)
 	if mysqlURL == "" {
 		log.Panicf("%s must be set", EnvMySQLURL)


### PR DESCRIPTION
For more flexibility, "mysqlurl" is constructed from "MYSQL_HOST", "MYSQL_PORT", "MYSQL_USER", "MYSQL_PASSWORD", and "MYSQL_DATABASE" environment variables only if all of them exist.