### PR TITLE
Fix to search repository in rescue

### DIFF
--- a/pkg/gh/run.go
+++ b/pkg/gh/run.go
@@ -71,6 +71,6 @@ func updateCache(ctx context.Context, owner, repo string) {
 		return
 	}
 	storeRateLimit(getRateLimitKey(owner, repo), resp.Rate)
-	responseCache.Set(getRunsCacheKey(owner, repo), runs.WorkflowRuns, 15*time.Minute)
+	responseCache.Set(getRunsCacheKey(owner, repo), runs.WorkflowRuns, 1*time.Minute)
 	logger.Logf(true, "found %d workflow runs in %s/%s", len(runs.WorkflowRuns), owner, repo)
 }

--- a/pkg/gh/run.go
+++ b/pkg/gh/run.go
@@ -25,14 +25,14 @@ func listRuns(ctx context.Context, client *github.Client, owner, repo string, op
 }
 
 // ListRuns get workflow runs that registered repository
-func ListRuns(ctx context.Context, owner, repo string) ([]*github.WorkflowRun, error) {
+func ListRuns(owner, repo string) ([]*github.WorkflowRun, error) {
 	if cachedRs, expiration, found := responseCache.GetWithExpiration(getRunsCacheKey(owner, repo)); found {
 		if time.Until(expiration).Minutes() <= 1 {
-			go updateCache(ctx, owner, repo)
+			go updateCache(owner, repo)
 		}
 		return cachedRs.([]*github.WorkflowRun), nil
 	}
-	go updateCache(ctx, owner, repo)
+	go updateCache(owner, repo)
 	return []*github.WorkflowRun{}, nil // retry next time
 }
 
@@ -45,7 +45,8 @@ func ClearRunsCache(owner, repo string) {
 	responseCache.Delete(getRunsCacheKey(owner, repo))
 }
 
-func updateCache(ctx context.Context, owner, repo string) {
+func updateCache(owner, repo string) {
+	ctx := context.Background()
 	var opts = &github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{
 			Page:    0,

--- a/pkg/gh/run.go
+++ b/pkg/gh/run.go
@@ -71,6 +71,6 @@ func updateCache(owner, repo string) {
 		return
 	}
 	storeRateLimit(getRateLimitKey(owner, repo), resp.Rate)
-	responseCache.Set(getRunsCacheKey(owner, repo), runs.WorkflowRuns, 1*time.Minute)
+	responseCache.Set(getRunsCacheKey(owner, repo), runs.WorkflowRuns, 3*time.Minute)
 	logger.Logf(true, "found %d workflow runs in %s/%s", len(runs.WorkflowRuns), owner, repo)
 }

--- a/pkg/gh/run.go
+++ b/pkg/gh/run.go
@@ -25,16 +25,15 @@ func listRuns(ctx context.Context, client *github.Client, owner, repo string, op
 }
 
 // ListRuns get workflow runs that registered repository
-func ListRuns(owner, repo string) ([]*github.WorkflowRun, error) {
+func ListRuns(ctx context.Context, owner, repo string) ([]*github.WorkflowRun, error) {
 	if cachedRs, expiration, found := responseCache.GetWithExpiration(getRunsCacheKey(owner, repo)); found {
 		if time.Until(expiration).Minutes() <= 1 {
-			go updateCache(context.Background(), owner, repo)
+			go updateCache(ctx, owner, repo)
 		}
-		logger.Logf(true, "found workflow runs (cache hit: expiration: %s) in %s/%s", expiration.Format("2006/01/02 15:04:05.000 -0700"), owner, repo)
 		return cachedRs.([]*github.WorkflowRun), nil
 	}
-	go updateCache(context.Background(), owner, repo)
-	return []*github.WorkflowRun{}, nil
+	go updateCache(ctx, owner, repo)
+	return []*github.WorkflowRun{}, nil // retry next time
 }
 
 func getRunsCacheKey(owner, repo string) string {

--- a/pkg/metric/scrape_github.go
+++ b/pkg/metric/scrape_github.go
@@ -45,11 +45,11 @@ func (s ScraperGitHub) Scrape(ctx context.Context, ds datastore.Datastore, ch ch
 func scrapePendingRuns(ctx context.Context, ds datastore.Datastore, ch chan<- prometheus.Metric) error {
 	gh.ActiveTargets.Range(func(key, value any) bool {
 		var pendings float64
-		scope := key.(string)
+		repoName := key.(string)
 		installationID := value.(int64)
-		target, err := ds.GetTargetByScope(ctx, scope)
+		target, err := datastore.SearchRepo(ctx, ds, repoName)
 		if err != nil {
-			logger.Logf(false, "failed to get target by scope (%s): %+v", scope, err)
+			logger.Logf(false, "failed to get target by scope (%s): %+v", repoName, err)
 			return true
 		}
 		owner, repo := target.OwnerRepo()

--- a/pkg/metric/scrape_github.go
+++ b/pkg/metric/scrape_github.go
@@ -56,7 +56,7 @@ func scrapePendingRuns(ctx context.Context, ds datastore.Datastore, ch chan<- pr
 		if repo == "" {
 			return true
 		}
-		runs, err := gh.ListRuns(ctx, owner, repo)
+		runs, err := gh.ListRuns(owner, repo)
 		if err != nil {
 			logger.Logf(false, "failed to list pending runs: %+v", err)
 			return true

--- a/pkg/metric/scrape_github.go
+++ b/pkg/metric/scrape_github.go
@@ -56,7 +56,7 @@ func scrapePendingRuns(ctx context.Context, ds datastore.Datastore, ch chan<- pr
 		if repo == "" {
 			return true
 		}
-		runs, err := gh.ListRuns(owner, repo)
+		runs, err := gh.ListRuns(ctx, owner, repo)
 		if err != nil {
 			logger.Logf(false, "failed to list pending runs: %+v", err)
 			return true

--- a/pkg/starter/starter.go
+++ b/pkg/starter/starter.go
@@ -443,7 +443,7 @@ func (s *Starter) reRunWorkflow(ctx context.Context) {
 					domain = "https://github.com"
 				}
 
-				logger.Logf(false, "receive webhook repository: %s/%s", domain, repoName)
+				logger.Logf(false, "rescue pending job: (repo: %s/%s, runID: %d)", domain, repoName, run.GetID())
 				target, err := datastore.SearchRepo(ctx, s.ds, repoName)
 				if err != nil {
 					logger.Logf(false, "failed to search registered target: %+v", err)


### PR DESCRIPTION
`ds.GetTargetByScope` does not support searching an organization target from the repository name.
This pull-request change to use `datastore.SearchRepo`.