### PR TITLE
Accept dependabot in GHES

### DIFF
--- a/pkg/web/webhook.go
+++ b/pkg/web/webhook.go
@@ -101,7 +101,7 @@ func receiveCheckRunWebhook(ctx context.Context, event *github.CheckRunEvent, ds
 	repoURL := repo.GetHTMLURL()
 
 	if action != "created" {
-		logger.Logf(true, "check_action is not created, ignore")
+		logger.Logf(true, "check_action is not created, ignore (%s)", action)
 		return nil
 	}
 
@@ -203,6 +203,11 @@ func receiveWorkflowJobWebhook(ctx context.Context, event *github.WorkflowJobEve
 }
 
 func isRequestedMyshoesLabel(labels []string) bool {
+	// Accept dependabot runner in GHES
+	if len(labels) == 1 && strings.EqualFold(labels[0], "dependabot") {
+		return true
+	}
+
 	for _, label := range labels {
 		if strings.EqualFold(label, "myshoes") || strings.EqualFold(label, "self-hosted") {
 			return true


### PR DESCRIPTION
With [myshoes#171](https://github.com/whywaita/myshoes/pull/171), myshoes was made compatible with dependabot on GitHub Enterprise Server (GHES).

However, since then, the specification for `runs-on` has changed. Specifically, the `self-hosted` label has been removed, and only `dependabot` is now specified under `runs-on`.

This update modifies myshoes to accommodate this change, ensuring it continues to function correctly.