### PR TITLE
Support node20

### DIFF
--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -335,9 +335,9 @@ fi
 # insert anything to setup env when running as a service
 
 # run the host process which keep the listener alive
-NODE_PATH="./externals/node16/bin/node"
+NODE_PATH="./externals/node20/bin/node"
 if [ ! -e "\${NODE_PATH}" ]; then
-  NODE_PATH="./externals/node12/bin/node"
+  NODE_PATH="./externals/node16/bin/node"
 fi
 \${NODE_PATH} ./bin/RunnerService.js \$* &
 PID=\$!


### PR DESCRIPTION
Remove node16 runtime in actions/runner by https://github.com/actions/runner/pull/3503

ref: https://github.com/actions/runner/releases/tag/v2.321.0

node22 is not published yet.