### PR TITLE
Load custom path from /etc/environment in setup script

### DIFF
--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -308,10 +308,10 @@ echo
 echo "Configuring ${runner_name} @ $runner_url"
 {{ if eq .RunnerArg "--once" -}}
 echo "./config.sh --unattended --url $runner_url --token *** --name $runner_name --labels myshoes"
-${sudo_prefix}./config.sh --unattended --url $runner_url --token $RUNNER_TOKEN --name $runner_name --labels myshoes{{.AdditionalLabels}}
+${sudo_prefix}bash -c "source /etc/environment; ./config.sh --unattended --url $runner_url --token $RUNNER_TOKEN --name $runner_name --labels myshoes{{.AdditionalLabels}}"
 {{ else -}}
 echo "./config.sh --unattended --url $runner_url --token *** --name $runner_name --labels myshoes {{.RunnerArg}}"
-${sudo_prefix}./config.sh --unattended --url $runner_url --token $RUNNER_TOKEN --name $runner_name --labels myshoes{{.AdditionalLabels}} {{.RunnerArg}}
+${sudo_prefix}bash -c "source /etc/environment; ./config.sh --unattended --url $runner_url --token $RUNNER_TOKEN --name $runner_name --labels myshoes{{.AdditionalLabels}} {{.RunnerArg}}"
 {{ end }}
 
 
@@ -370,9 +370,9 @@ fi
 # So, we need to load /etc/environment for job on self-hosted runner.
 
 {{ if eq .RunnerArg "--once" -}}
-echo "./bin/runsvc.sh {{.RunnerArg}}"
+echo 'bash -c "source /etc/environment; ./bin/runsvc.sh  {{.RunnerArg}}"'
 ${sudo_prefix}bash -c "source /etc/environment; ./bin/runsvc.sh  {{.RunnerArg}}"
 {{ else -}}
-echo "./bin/runsvc.sh"
+echo 'bash -c "source /etc/environment; ./bin/runsvc.sh"'
 ${sudo_prefix}bash -c "source /etc/environment; ./bin/runsvc.sh"
 {{ end }}`

--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -365,10 +365,14 @@ fi
 #---------------------------------------
 # run!
 #---------------------------------------
+
+# GitHub-hosted runner load /etc/environment in /opt/runner/provisioner/provisioner.
+# So, we need to load /etc/environment for job on self-hosted runner.
+
 {{ if eq .RunnerArg "--once" -}}
 echo "./bin/runsvc.sh {{.RunnerArg}}"
-${sudo_prefix}./bin/runsvc.sh {{.RunnerArg}}
+${sudo_prefix}bash -c "source /etc/environment; ./bin/runsvc.sh  {{.RunnerArg}}"
 {{ else -}}
 echo "./bin/runsvc.sh"
-${sudo_prefix}./bin/runsvc.sh
+${sudo_prefix}bash -c "source /etc/environment; ./bin/runsvc.sh"
 {{ end }}`


### PR DESCRIPTION
We found *not* loaded a custom PATH that generated from a script of `actions/runner-images` in myshoes runner.

But I found setting environment values in `/opt/runner/provisioner/provisioner` in GitHub-hosted runner.

```
root         715  0.2  0.8 274207752 146996 ?    Ssl  17:29   0:02 /opt/runner/provisioner/provisioner --agentdirectory /home/runner/runners --settings /opt/runner/provisioner/.settings
root        1715  0.1  0.1 1242976 22164 ?       Sl   17:37   0:01  \_ /opt/runner/provisioner/etc/provjobd
runner      1727  0.2  0.7 274209476 130888 ?    Sl   17:37   0:02  \_ /home/runner/runners/2.321.0/bin/Runner.Listener run
runner      1743  0.5  1.1 274293808 183244 ?    Sl   17:37   0:05      \_ /home/runner/runners/2.321.0/bin/Runner.Worker spawnclient 155 158
```

pid 1727 ( Runner.Listener )

```
runner@fv-az1154-870:~/work/sandbox/sandbox$ sudo cat /proc/1727/environ
DEBIAN_FRONTEND=noninteractiveJAVA_HOME=/usr/lib/jvm/temurin-11-jdk-amd64ANT_HOME=/usr/share/antSTATS_RDCL=trueANDROID_HOME=/usr/local/lib/android/sdkANDROID_NDK_LATEST_HOME=/usr/local/lib/android/sdk/ndk/27.2.12479018ImageOS=ubuntu20JAVA_HOME_8_X64=/usr/lib/jvm/temurin-8-jdk-amd64SGX_AESM_ADDR=1GRADLE_HOME=/usr/share/gradle-8.12STATS_VMFE=truePIPX_BIN_DIR=/opt/pipx_binLEIN_JAR=/usr/local/lib/lein/self-installs/leiningen-2.11.2-standalone.jarANDROID_SDK_ROOT=/usr/local/lib/
android/sdkGOROOT_1_22_X64=/opt/hostedtoolcache/go/1.22.10/x64DOTNET_NOLOGO=1STATS_EXT=trueImageVersion=20250105.1.0GECKOWEBDRIVER=/usr/local/share/gecko_driverCONDA=/usr/share/minicondaDOTNET_SKIP_FIRST_TIME_EXPERIENCE=1GOROOT_1_23_X64=/opt/hostedtoolcache/go/1.23.4/x64ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=/opt/actionarchivecacheLANG=C.UTF-8PIPX_HOME=/opt/pipxJAVA_HOME_21_X64=/usr/lib/jvm/temurin-21-jdk-amd64ANDROID_NDK=/usr/local/lib/android/sdk/ndk/27.2.12479018STATS_D_TC=
trueRUNNER_USER=runnerPERFLOG_LOCATION_SETTING=RUNNER_PERFLOGXDG_CONFIG_HOME=/home/runner/.configAGENT_TOOLSDIRECTORY=/opt/hostedtoolcacheSTATS_TIS=miningSTATS_D_D=falseSWIFT_PATH=/usr/share/swift/usr/binHOMEBREW_CLEANUP_PERIODIC_FULL_DAYS=3650STATS_V3PS=trueINVOCATION_ID=5ccb7f0db49a4454bf30b9ada5435511PATH=/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/l
ocal/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/binJOURNAL_STREAM=8:24166GHCUP_INSTALL_BASE_PREFIX=/usr/localCHROME_BIN=/usr/bin/google-chromeLEIN_HOME=/usr/local/lib/leinSTATS_EXTP=https://provjobdprod.z13.web.core.windows.net/settings/provjobdsettings-latest/provjobd.dataAZURE_EXTENSION_DIR=/opt/az/azcliextensionsJAVA_HOME_11_X64=/usr/lib/jvm/temurin-11-jdk-amd64DOTNET_MULTILEVEL_LOOKUP=0STATS_VMD=trueGOROOT_1_21_X64=/opt/hostedtoo
lcache/go/1.21.13/x64BOOTSTRAP_HASKELL_NONINTERACTIVE=1SELENIUM_JAR_PATH=/usr/share/java/selenium-server.jarSTATS_TRP=trueSTATS_D=falseRUNNER_TOOL_CACHE=/opt/hostedtoolcacheSTATS_PIP=falseNVM_DIR=/home/runner/.nvmSTATS_UE=trueEDGEWEBDRIVER=/usr/local/share/edge_driverJAVA_HOME_17_X64=/usr/lib/jvm/temurin-17-jdk-amd64POWERSHELL_DISTRIBUTION_CHANNEL=GitHub-Actions-ubuntu20VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkgDEPLOYMENT_BASEPATH=/opt/runnerANDROID_NDK_HOME=/usr/local/
lib/android/sdk/ndk/27.2.12479018CHROMEWEBDRIVER=/usr/local/share/chromedriver-linux64ACCEPT_EULA=YHOMEBREW_NO_AUTO_UPDATE=1ANDROID_NDK_ROOT=/usr/local/lib/android/sdk/ndk/27.2.12479018USER=runnerHOME=/home/runnerRUNNER_PERFLOG=/home/runner/perflogXDG_RUNTIME_DIR=/run/user/1001
```

pid 715 (provisioner)

```
runner@fv-az1154-870:~/work/sandbox/sandbox$ sudo cat /proc/715/environ
LANG=C.UTF-8PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/binSGX_AESM_ADDR=1INVOCATION_ID=5ccb7f0db49a4454bf30b9ada5435511JOURNAL_STREAM=8:24166
```

So this PR becomes loading `/etc/environment` in the setup script.