### PR TITLE
Set installation object in rescue

### DIFF
--- a/pkg/gh/installation.go
+++ b/pkg/gh/installation.go
@@ -102,6 +102,22 @@ func _listAppsInstalledRepo(ctx context.Context, installationID int64) ([]*githu
 	return repositories, nil
 }
 
+// GetInstallationByID returns installation from cache by ID
+func GetInstallationByID(ctx context.Context, installationID int64) (*github.Installation, error) {
+	installations, err := listInstallations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get installations: %w", err)
+	}
+
+	for _, installation := range installations {
+		if installation.GetID() == installationID {
+			return installation, nil
+		}
+	}
+
+	return nil, fmt.Errorf("installation not found: %d", installationID)
+}
+
 // PurgeInstallationCache purges the cache of installations
 func PurgeInstallationCache(ctx context.Context) error {
 	installations, err := listInstallations(ctx)

--- a/pkg/starter/starter.go
+++ b/pkg/starter/starter.go
@@ -468,7 +468,7 @@ func enqueueRescueRun(ctx context.Context, pendingRun datastore.PendingWorkflowR
 		// Get full installation data from cache
 		installation, err := gh.GetInstallationByID(ctx, installationID)
 		if err != nil {
-			logger.Logf(false, "failed to get installation from cache, using minimal data: %+v", err)
+      logger.Logf(false, "failed to get installation from cache (installationID: %d), using minimal data: %+v", installationID, err)
 			// Fallback to minimal installation data
 			installation = &github.Installation{
 				ID: &installationID,


### PR DESCRIPTION
fixes: #230 

This pull request introduces enhancements to GitHub installation handling, including a new function to retrieve installation data from the cache and updates to the workflow rescue logic to utilize this cached data. These changes improve efficiency and fallback mechanisms when dealing with GitHub installations.

### Enhancements to GitHub installation handling:

* **Added `GetInstallationByID` function**: Introduced a new function in `pkg/gh/installation.go` to retrieve installation data from the cache using an installation ID. This function iterates through cached installations and provides fallback error handling if the installation is not found.

### Updates to workflow rescue logic:

* **Utilized cached installation data in `enqueueRescueRun`**: Modified the workflow rescue logic in `pkg/starter/starter.go` to retrieve full installation data from the cache using the new `GetInstallationByID` function. Added fallback to minimal installation data in case of cache retrieval failure, ensuring robustness.
* **Improved event object construction**: Updated the `WorkflowJobEvent` creation process to include detailed organization, sender, and installation data, enhancing the accuracy and completeness of the event payload.