### PR TITLE
Don't store error when ErrInvalidLabel

### DIFF
--- a/pkg/starter/starter.go
+++ b/pkg/starter/starter.go
@@ -223,6 +223,7 @@ func (s *Starter) ProcessJob(ctx context.Context, job datastore.Job) error {
 			if err := incrementDeleteJobMap(job); err != nil {
 				return fmt.Errorf("failed to increment delete metrics: %w", err)
 			}
+			return nil
 		}
 
 		if err := datastore.UpdateTargetStatus(ctx, s.ds, job.TargetID, datastore.TargetStatusErr, fmt.Sprintf("failed to create an instance (job ID: %s)", job.UUID)); err != nil {


### PR DESCRIPTION
fixes: #232 

ErrInvalidLabel is not an error of booting the runner.  So the myshoes needn't tell the error to the user.

## Generated 

This pull request introduces a small but significant change to the `ProcessJob` function in `pkg/starter/starter.go`. The change ensures that the function exits early with a `nil` return value after successfully incrementing the delete job metrics.

* [`pkg/starter/starter.go`](diffhunk://#diff-3a0c64b483dd2fed243139d0725e8be15f12e642cd167cd9ce85923e63d138c5R226): Added an early `return nil` statement after `incrementDeleteJobMap(job)` to prevent further execution when the delete metrics are successfully incremented.