### PR TITLE
Fix a flag for found job in rescue

### DIFF
--- a/pkg/datastore/github.go
+++ b/pkg/datastore/github.go
@@ -56,6 +56,7 @@ func GetPendingWorkflowRunByRecentRepositories(ctx context.Context, ds Datastore
 	var result []PendingWorkflowRunWithTarget
 	// We ignore the pending run if the job is already queued.
 	for _, pendingRun := range pendingRuns {
+		found := false
 		for _, job := range queuedJob {
 			webhookEvent, err := github.ParseWebHook("workflow_job", []byte(job.CheckEventJSON))
 			if err != nil {
@@ -71,11 +72,14 @@ func GetPendingWorkflowRunByRecentRepositories(ctx context.Context, ds Datastore
 
 			if pendingRun.WorkflowRun.GetID() == workflowJob.GetWorkflowJob().GetRunID() {
 				logger.Logf(true, "found job in datastore, So will ignore: (repo: %s, runID: %d)", pendingRun.WorkflowRun.GetRepository().GetFullName(), pendingRun.WorkflowRun.GetID())
-				continue
+				found = true
+				break
 			}
 		}
 
-		result = append(result, pendingRun)
+		if !found {
+			result = append(result, pendingRun)
+		}
 	}
 
 	return result, nil

--- a/pkg/datastore/github.go
+++ b/pkg/datastore/github.go
@@ -71,7 +71,7 @@ func GetPendingWorkflowRunByRecentRepositories(ctx context.Context, ds Datastore
 			}
 
 			if pendingRun.WorkflowRun.GetID() == workflowJob.GetWorkflowJob().GetRunID() {
-				logger.Logf(true, "found job in datastore, So will ignore: (repo: %s, runID: %d)", pendingRun.WorkflowRun.GetRepository().GetFullName(), pendingRun.WorkflowRun.GetID())
+				logger.Logf(true, "found job in datastore, So will ignore: (repo: %s, gh_run_id: %d, gh_job_id: %d)", pendingRun.WorkflowRun.GetRepository().GetFullName(), pendingRun.WorkflowRun.GetID(), workflowJob.GetWorkflowJob().GetID())
 				found = true
 				break
 			}
@@ -144,10 +144,10 @@ func getPendingRunByRepo(ctx context.Context, client *github.Client, owner, repo
 			oldMinutes := 10
 			sinceMinutes := time.Since(r.CreatedAt.Time).Minutes()
 			if sinceMinutes >= float64(oldMinutes) {
-				logger.Logf(false, "run %d is pending over %d minutes, So will enqueue (repo: %s/%s)", r.GetID(), oldMinutes, owner, repo)
+				logger.Logf(false, "workflow run %d is pending over %d minutes, So will enqueue (repo: %s/%s)", r.GetID(), oldMinutes, owner, repo)
 				pendingRuns = append(pendingRuns, r)
 			} else {
-				logger.Logf(true, "run %d is pending, but not over %d minutes. So ignore (since: %f minutes, repo: %s/%s)", r.GetID(), oldMinutes, sinceMinutes, owner, repo)
+				logger.Logf(true, "workflow run %d is pending, but not over %d minutes. So ignore (since: %f minutes, repo: %s/%s)", r.GetID(), oldMinutes, sinceMinutes, owner, repo)
 			}
 		}
 	}


### PR DESCRIPTION
We fixed a bug with the rescue bomb in the pending run.

## Summary

This pull request refines the logic in the function `GetPendingWorkflowRunByRecentRepositories` within the `pkg/datastore/github.go` file. The update improves the handling of pending workflow runs by ensuring that jobs already queued are correctly identified and excluded from the result.

### Improvements to workflow run filtering:

* Added a `found` flag to track whether a pending workflow run matches a queued job. This ensures that the loop breaks immediately upon finding a match, optimizing performance.
* Updated the logic to append only unmatched pending workflow runs to the `result` slice, enhancing the accuracy of the filtering process.