### PR TITLE
Add check of invalid label in rescue

### DIFF
--- a/pkg/gh/label.go
+++ b/pkg/gh/label.go
@@ -1,0 +1,18 @@
+package gh
+
+import "strings"
+
+// IsRequestedMyshoesLabel checks if the job has appropriate labels for myshoes
+func IsRequestedMyshoesLabel(labels []string) bool {
+	// Accept dependabot runner in GHES
+	if len(labels) == 1 && strings.EqualFold(labels[0], "dependabot") {
+		return true
+	}
+
+	for _, label := range labels {
+		if strings.EqualFold(label, "myshoes") || strings.EqualFold(label, "self-hosted") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -46,7 +46,6 @@ func (s *Starter) getSetupScript(ctx context.Context, targetScope, runnerName st
 
 func (s *Starter) getSetupRawScript(ctx context.Context, targetScope, runnerName string) (string, error) {
 	runnerUser := config.Config.RunnerUser
-	githubURL := config.Config.GitHubURL
 
 	targetRunnerVersion := s.runnerVersion
 	if strings.EqualFold(s.runnerVersion, "latest") {
@@ -77,9 +76,7 @@ func (s *Starter) getSetupRawScript(ctx context.Context, targetScope, runnerName
 	}
 
 	var labels []string
-	if githubURL != "" && githubURL != "https://github.com" {
-		labels = append(labels, "dependabot")
-	}
+	labels = append(labels, "dependabot")
 
 	v := templateCreateLatestRunnerOnceValue{
 		Scope:                   targetScope,

--- a/pkg/starter/scripts.go
+++ b/pkg/starter/scripts.go
@@ -76,6 +76,7 @@ func (s *Starter) getSetupRawScript(ctx context.Context, targetScope, runnerName
 	}
 
 	var labels []string
+  // The "dependabot" label is always added to ensure compatibility with Dependabot-related workflows.
 	labels = append(labels, "dependabot")
 
 	v := templateCreateLatestRunnerOnceValue{

--- a/pkg/starter/starter.go
+++ b/pkg/starter/starter.go
@@ -483,6 +483,13 @@ func enqueueRescueRun(ctx context.Context, pendingRun datastore.PendingWorkflowR
 			continue
 		}
 
+		// Check if the job has appropriate labels for myshoes
+		if !gh.IsRequestedMyshoesLabel(job.Labels) {
+			logger.Logf(true, "skip rescue job because it doesn't have myshoes labels: (repo: %s, gh_run_id: %d, gh_job_id: %d, labels: %v)",
+				fullName, pendingRun.WorkflowRun.GetID(), job.GetID(), job.Labels)
+			continue
+		}
+
 		// Get installation ID from target scope
 		installationID, err := gh.IsInstalledGitHubApp(ctx, target.Scope)
 		if err != nil {

--- a/pkg/web/webhook.go
+++ b/pkg/web/webhook.go
@@ -194,7 +194,7 @@ func receiveWorkflowJobWebhook(ctx context.Context, event *github.WorkflowJobEve
 	repoURL := repo.GetHTMLURL()
 
 	labels := event.GetWorkflowJob().Labels
-	if !isRequestedMyshoesLabel(labels) {
+	if !gh.IsRequestedMyshoesLabel(labels) {
 		// is not request myshoes, So will be ignored
 		logger.Logf(true, "label \"myshoes\" is not found in labels, so ignore (labels: %s)", labels)
 		return nil
@@ -221,16 +221,3 @@ func receiveWorkflowJobWebhook(ctx context.Context, event *github.WorkflowJobEve
 	return nil
 }
 
-func isRequestedMyshoesLabel(labels []string) bool {
-	// Accept dependabot runner in GHES
-	if len(labels) == 1 && strings.EqualFold(labels[0], "dependabot") {
-		return true
-	}
-
-	for _, label := range labels {
-		if strings.EqualFold(label, "myshoes") || strings.EqualFold(label, "self-hosted") {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
fixes: https://github.com/whywaita/myshoes/issues/228

- We check labels in the rescue job.
    - The myshoes don't rescue a job that was not generated by myshoes.
- We always add the `dependabot` label.
    - This change supports https://docs.github.com/en/code-security/dependabot/maintain-dependencies/managing-dependabot-on-self-hosted-runners

## Summary (generated)

This pull request refactors label-checking logic to improve code reusability and maintainability. The key changes include introducing a new utility function `IsRequestedMyshoesLabel` in the `pkg/gh/label.go` file and replacing duplicate label-checking logic with calls to this function across the codebase.

### Refactoring and code reuse:

* Added the `IsRequestedMyshoesLabel` function in `pkg/gh/label.go` to encapsulate the logic for checking if a job has appropriate labels (`myshoes`, `self-hosted`, or `dependabot`).
* Replaced the inline label-checking logic in `pkg/web/webhook.go` with a call to the new `gh.IsRequestedMyshoesLabel` function, removing the redundant `isRequestedMyshoesLabel` function. [[1]](diffhunk://#diff-15016cb914d0193cbb5f757f3923533ae29b65c85d6493dabbd8d282e5538efbL197-R197) [[2]](diffhunk://#diff-15016cb914d0193cbb5f757f3923533ae29b65c85d6493dabbd8d282e5538efbL224-L236)

### Functional changes:

* Updated the `enqueueRescueRun` function in `pkg/starter/starter.go` to skip rescue jobs without the required labels by using the new `gh.IsRequestedMyshoesLabel` function. This adds logging for skipped jobs.

### Minor adjustments:

* Removed unused `githubURL` variable in `pkg/starter/scripts.go` and adjusted related code for label handling. [[1]](diffhunk://#diff-30fdc51e3bcb799ccedf9420c0a5148af3869087e341a21fd1a0362e94732208L49) [[2]](diffhunk://#diff-30fdc51e3bcb799ccedf9420c0a5148af3869087e341a21fd1a0362e94732208L80-L82)