### PR TITLE
Add runner UUID to delete error log message

### DIFF
--- a/pkg/runner/runner_delete.go
+++ b/pkg/runner/runner_delete.go
@@ -127,7 +127,7 @@ func (m *Manager) removeRunners(ctx context.Context, t datastore.Target) error {
 
 			if err := m.removeRunner(cctx, t, runner, ghRunners); err != nil {
 				DeleteRetryCount.Store(runner.UUID, count+1)
-				logger.Logf(false, "failed to delete runner: %+v", err)
+				logger.Logf(false, "failed to delete runner (runner UUID: %s): %+v", runner.UUID, err)
 			} else {
 				DeleteRetryCount.Delete(runner.UUID)
 			}


### PR DESCRIPTION
This pull request makes a minor improvement to the error logging in the runner deletion process. The log message now includes the runner's UUID, making it easier to identify which runner failed to delete.

* Improved error logging in `removeRunners` by including the runner UUID in the log message for failed deletions.