### PR TITLE
fix(metrics): prevent GitHub API calls from hanging forever

### DIFF
--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof" // register pprof handlers on the localhost:6060 DefaultServeMux
 	"runtime"
 	"strings"
 	"time"

--- a/pkg/gh/github.go
+++ b/pkg/gh/github.go
@@ -16,6 +16,21 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// githubHTTPClientTimeout is the maximum duration of a single GitHub API
+// request (including connection, TLS handshake and response). Without it a
+// stalled connection to the GitHub API blocks forever, which can hang callers
+// such as the /metrics collector and the starter loop.
+const githubHTTPClientTimeout = 10 * time.Second
+
+// newGitHubHTTPClient creates an *http.Client for the GitHub API with a bounded
+// timeout so no single request can hang indefinitely.
+func newGitHubHTTPClient(rt http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: rt,
+		Timeout:   githubHTTPClientTimeout,
+	}
+}
+
 var (
 	// ErrNotFound is error for not found
 	ErrNotFound = fmt.Errorf("not found")
@@ -63,10 +78,10 @@ func NewClient(token string) (*github.Client, error) {
 	clientTransport := newInstrumentedTransport(transport)
 
 	if !config.Config.IsGHES() {
-		return github.NewClient(&http.Client{Transport: clientTransport}), nil
+		return github.NewClient(newGitHubHTTPClient(clientTransport)), nil
 	}
 
-	return github.NewClient(&http.Client{Transport: clientTransport}).WithEnterpriseURLs(config.Config.GitHubURL, config.Config.GitHubURL)
+	return github.NewClient(newGitHubHTTPClient(clientTransport)).WithEnterpriseURLs(config.Config.GitHubURL, config.Config.GitHubURL)
 }
 
 // NewClientGitHubApps create a client of GitHub using Private Key from GitHub Apps
@@ -74,7 +89,7 @@ func NewClient(token string) (*github.Client, error) {
 // docs: https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-a-github-app
 func NewClientGitHubApps() (*github.Client, error) {
 	if !config.Config.IsGHES() {
-		return github.NewClient(&http.Client{Transport: newInstrumentedTransport(&appTransport)}), nil
+		return github.NewClient(newGitHubHTTPClient(newInstrumentedTransport(&appTransport))), nil
 	}
 
 	apiEndpoint, err := getAPIEndpoint()
@@ -84,7 +99,7 @@ func NewClientGitHubApps() (*github.Client, error) {
 
 	itr := appTransport
 	itr.BaseURL = apiEndpoint.String()
-	return github.NewClient(&http.Client{Transport: newInstrumentedTransport(&appTransport)}).WithEnterpriseURLs(config.Config.GitHubURL, config.Config.GitHubURL)
+	return github.NewClient(newGitHubHTTPClient(newInstrumentedTransport(&appTransport))).WithEnterpriseURLs(config.Config.GitHubURL, config.Config.GitHubURL)
 }
 
 // NewClientInstallation create a client of GitHub using installation ID from GitHub Apps
@@ -94,14 +109,14 @@ func NewClientInstallation(installationID int64) (*github.Client, error) {
 	itr := getInstallationTransport(installationID)
 
 	if !config.Config.IsGHES() {
-		return github.NewClient(&http.Client{Transport: newInstrumentedTransport(itr)}), nil
+		return github.NewClient(newGitHubHTTPClient(newInstrumentedTransport(itr))), nil
 	}
 	apiEndpoint, err := getAPIEndpoint()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get GitHub API Endpoint: %w", err)
 	}
 	itr.BaseURL = apiEndpoint.String()
-	return github.NewClient(&http.Client{Transport: newInstrumentedTransport(itr)}).WithEnterpriseURLs(config.Config.GitHubURL, config.Config.GitHubURL)
+	return github.NewClient(newGitHubHTTPClient(newInstrumentedTransport(itr))).WithEnterpriseURLs(config.Config.GitHubURL, config.Config.GitHubURL)
 }
 
 func setInstallationTransport(installationID int64, itr ghinstallation.Transport) {
@@ -160,7 +175,7 @@ func ExistGitHubRepository(scope string, accessToken string) error {
 		return fmt.Errorf("failed to get repository url: %w", err)
 	}
 
-	client := &http.Client{Transport: newInstrumentedTransport(http.DefaultTransport)}
+	client := newGitHubHTTPClient(newInstrumentedTransport(http.DefaultTransport))
 	req, err := http.NewRequest(http.MethodGet, repoURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/pkg/gh/installation.go
+++ b/pkg/gh/installation.go
@@ -21,7 +21,7 @@ func listInstallations(ctx context.Context) ([]*github.Installation, error) {
 
 	responseCache.Set(getCacheInstallationsKey(), inst, 1*time.Hour)
 
-	return _listInstallations(ctx)
+	return inst, nil
 }
 
 func getCacheInstallationsKey() string {
@@ -67,7 +67,7 @@ func listAppsInstalledRepo(ctx context.Context, installationID int64) ([]*github
 
 	responseCache.Set(getCacheInstalledRepoKey(installationID), inst, 1*time.Hour)
 
-	return _listAppsInstalledRepo(ctx, installationID)
+	return inst, nil
 }
 
 func getCacheInstalledRepoKey(installationID int64) string {


### PR DESCRIPTION
## Summary

Fixes `GET /metrics` hanging and never returning a response. On a production pod, `/metrics` returned nothing after 60s (`curl localhost:80/metrics` → `http=000 time_total=60s size=0`).

## Root cause

The `/metrics` Prometheus collector performs live GitHub API calls (`Apps.ListInstallations`, `Actions.ListRepositoryWorkflowRuns`, installation-token refresh) **synchronously** and waits on them with `wg.Wait()`. The GitHub `*http.Client` has no `Timeout` (and `http.DefaultTransport` has no `ResponseHeaderTimeout`), so when a connection to the GitHub API stalls, the request **blocks indefinitely** and `GET /metrics` hangs.

Worse, `responseCache` is only populated on a *successful* call, so while stalled the two Prometheus scrapers and the starter loop keep re-issuing the same live API calls, which sustains the stall (a self-reinforcing loop).

### Evidence from the running pod (last 15 min)

| Metric | Count |
|---|---|
| `GET /metrics` | 273 |
| scrape failures `name: github` | 283 |
| scrape failures `datastore` / `memory` | 0 / 0 |
| `context canceled` | 566 |

```
get installations from GitHub, page: 0, now all installations: 0   # always stuck at page 0 / 0 results, never completes
get workflow runs from GitHub, page: 0, now all runners: 0         # same
```

The `datastore` / `memory` scrapers had 0 failures, `api.github.com/zen` from the pod responded in ~190ms, and the pod had only 15 TCP sockets / 12 threads (no exhaustion). The only thing stuck was the github scraper waiting on the GitHub App API.

## Changes

- **`pkg/gh/github.go`**: give every GitHub `*http.Client` a `Timeout` (10s) via a new `newGitHubHTTPClient` helper, so no single request can hang forever. This also protects the starter loop and runner deletion (which were hanging the same way, e.g. `unexpected EOF`).
- **`pkg/gh/installation.go`**: fix `listInstallations` / `listAppsInstalledRepo` calling the underlying `_list*` function **twice** on a cache miss (the first result was cached and then discarded), which doubled GitHub API load.

Note: the `/metrics` handler intentionally keeps `r.Context()` and does **not** add its own deadline — the scrape timeout is the scraper's (Prometheus) responsibility.
- **`cmd/server/cmd.go`**: import `net/http/pprof`. The server already listens on `localhost:6060` and sets `SetBlockProfileRate` / `SetMutexProfileFraction`, but the pprof handlers were never registered, so every `/debug/pprof/*` endpoint returned 404. This makes pprof usable for future investigations (it was unavailable during this one).

## Follow-up (separate PR)

This PR stops the hang via timeouts, which is a mitigation. The longer-term fix is to stop doing synchronous live API calls inside the collector and instead **refresh in the background and serve cached values** (a Prometheus collector should not block on external I/O). That is a larger behavioral change, so it is kept separate.

## Testing

- `go build ./...` and `go vet ./pkg/gh/... ./pkg/web/... ./cmd/server/...` pass.
- `go test ./pkg/gh/...` passes (`pkg/web` requires Docker via dockertest and was not run in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
