### PR TITLE
fix(datastore/mysql): change github_token column to TEXT

### DIFF
--- a/pkg/datastore/mysql/schema.sql
+++ b/pkg/datastore/mysql/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE `targets` (
     `uuid` VARCHAR(36) NOT NULL PRIMARY KEY,
     `scope` VARCHAR(255) NOT NULL,
     `ghe_domain` VARCHAR(255),
-    `github_token` VARCHAR(255) NOT NULL,
+    `github_token` TEXT NOT NULL,
     `token_expired_at` TIMESTAMP NOT NULL,
     `resource_type` ENUM('nano', 'micro', 'small', 'medium', 'large', 'xlarge', '2xlarge', '3xlarge', '4xlarge') NOT NULL,
     `provider_url` VARCHAR(255),

--- a/pkg/datastore/mysql/target_test.go
+++ b/pkg/datastore/mysql/target_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,10 +19,15 @@ import (
 
 var testTargetID = uuid.FromStringOrNil("8a72d42c-372c-4e0d-9c6a-4304d44af137")
 var testTargetID2 = uuid.FromStringOrNil("d14ccfea-b123-4ada-974e-bbff0937e9c7")
+var testTargetID3 = uuid.FromStringOrNil("5c1816ff-4813-46b0-b1ba-30d135a2f3f5")
 var testScopeOrg = "octocat"
 var testScopeRepo = "octocat/hello-world"
 var testScopeRepo2 = "octocat/hello-world2"
 var testGitHubToken = "this-code-is-github-token"
+
+// testGitHubTokenLong exceeds 255 characters. GitHub does not guarantee the length of tokens,
+// so the column must accept tokens longer than VARCHAR(255).
+var testGitHubTokenLong = strings.Repeat("t", 1024)
 var testRunnerUser = "testing-super-user"
 var testProviderURL = "/shoes-mock"
 var testTime = time.Date(2037, 9, 3, 0, 0, 0, 0, time.UTC)
@@ -89,6 +95,32 @@ func TestMySQL_CreateTarget(t *testing.T) {
 				},
 				Status:       datastore.TargetStatusActive,
 				ResourceType: datastore.ResourceTypeNano,
+				ProviderURL: sql.NullString{
+					String: testProviderURL,
+					Valid:  true,
+				},
+			},
+			err: false,
+		},
+		{
+			input: datastore.Target{
+				UUID:           testTargetID3,
+				Scope:          testScopeOrg,
+				GitHubToken:    testGitHubTokenLong,
+				TokenExpiredAt: testTime,
+				ResourceType:   datastore.ResourceTypeNano,
+				ProviderURL: sql.NullString{
+					String: testProviderURL,
+					Valid:  true,
+				},
+			},
+			want: &datastore.Target{
+				UUID:           testTargetID3,
+				Scope:          testScopeOrg,
+				GitHubToken:    testGitHubTokenLong,
+				TokenExpiredAt: testTime,
+				Status:         datastore.TargetStatusActive,
+				ResourceType:   datastore.ResourceTypeNano,
 				ProviderURL: sql.NullString{
 					String: testProviderURL,
 					Valid:  true,
@@ -612,6 +644,28 @@ func TestMySQL_UpdateToken(t *testing.T) {
 			want: &datastore.Target{
 				Scope:          testScopeRepo,
 				GitHubToken:    "new-token",
+				TokenExpiredAt: testTime.Add(1 * time.Hour),
+				ResourceType:   datastore.ResourceTypeNano,
+				ProviderURL: sql.NullString{
+					String: testProviderURL,
+					Valid:  true,
+				},
+				Status: datastore.TargetStatusActive,
+				StatusDescription: sql.NullString{
+					String: "",
+					Valid:  false,
+				},
+			},
+			err: false,
+		},
+		{
+			input: Input{
+				token:   testGitHubTokenLong,
+				expired: testTime.Add(1 * time.Hour),
+			},
+			want: &datastore.Target{
+				Scope:          testScopeRepo,
+				GitHubToken:    testGitHubTokenLong,
 				TokenExpiredAt: testTime.Add(1 * time.Hour),
 				ResourceType:   datastore.ResourceTypeNano,
 				ProviderURL: sql.NullString{


### PR DESCRIPTION
## Why

`targets.github_token` is `VARCHAR(255)`. GitHub does not guarantee the length of tokens (the token format changed in 2021, the token length changed in 2026/08/14 and may change again), and fine-grained PATs are already ~93 characters. If a token ever exceeds 255 characters, INSERT/UPDATE fails (strict mode) or the token is silently truncated.

## What

- Change `targets.github_token` from `VARCHAR(255)` to `TEXT`.
  - The column is not part of any index, so there is no index-length concern.
  - Consistent with other externally-sized columns in the schema (`cloud_id`, `request_webhook`, `check_event`).
- Add test cases that store and read back a 1024-character token via `CreateTarget` / `UpdateToken`. These fail against the previous `VARCHAR(255)` schema.

## Migration for existing deployments

`schema.sql` is only applied on fresh setup. Existing databases need:

```sql
ALTER TABLE targets MODIFY COLUMN `github_token` TEXT NOT NULL;
```